### PR TITLE
Kjorskra number keyboard

### DIFF
--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -515,7 +515,6 @@ class Kjorskra extends PureComponent {
                       <Autocomplete
                         ref={this.onAutocompleteMounted}
                         type="text"
-                        autoFocus
                         onChange={this.submitCurrentAddress}
                         placeholder="Núverandi heimilisfang"
                         className={s.input}

--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -474,7 +474,8 @@ class Kjorskra extends PureComponent {
                 <input
                   autoFocus
                   value={kennitala}
-                  type="text"
+                  type="number"
+                  pattern="[\d]*"
                   placeholder="Sláðu inn kennitöluna þína"
                   className={s.input}
                   onChange={e => this.onInputChange('kennitala', e)}

--- a/src/routes/kjorskra/Kjorskra.scss
+++ b/src/routes/kjorskra/Kjorskra.scss
@@ -127,6 +127,13 @@
   color: #808080;
   box-sizing: border-box;
   padding: 0 1rem;
+  -moz-appearance:textfield;
+}
+
+.input::-webkit-inner-spin-button,
+.input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 
 .submit {

--- a/src/routes/kjorskra/index.js
+++ b/src/routes/kjorskra/index.js
@@ -12,24 +12,20 @@ export default ({ params }) => {
       if (process.env.BROWSER) {
         nidurstada = atob(nidurstada);
       } else {
-        //@TODO fix the server side rendering wrong text cuz lame encoding, need iso-8859-1
-        nidurstada = Buffer.from('nidurstada', 'base64').toString('utf-8');
+        nidurstada = Buffer.from(nidurstada, 'base64').toString('binary');
       }
 
       nidurstada = nidurstada.split('|');
-    } catch (e) {
-      //@TODO polyfil the base64 decoding
-      nidurstada = [];
-    }
 
-    const [fornafn, kjorstadur, kjordeild, kjordaemi] = nidurstada;
+      const [fornafn, kjorstadur, kjordeild, kjordaemi] = nidurstada;
 
-    nidurstadaObj = {
-      fornafn,
-      kjorstadur,
-      kjordeild,
-      kjordaemi
-    };
+      nidurstadaObj = {
+        fornafn,
+        kjorstadur,
+        kjordeild,
+        kjordaemi
+      };
+    } catch (e) {}
   }
 
   const title = nidurstadaObj


### PR DESCRIPTION
1. Uses number keyboard when opened on mobile.
2. Decodes the shareable url correctly on the server side.
3. Removed autoFocus on address input after getting the result. Made it awkward on mobile as the keyboard would show after getting the result.