### PR TITLE
Kjorstad lookup using mapzen

### DIFF
--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -433,12 +433,15 @@ class Kjorskra extends PureComponent {
     this.getDistance({
       ...position,
       costing: 'pedestrian'
-    }).then(data => this.setState({ walking: data }));
-
-    this.getDistance({
-      ...position,
-      costing: 'bicycle'
-    }).then(data => this.setState({ bicycling: data }));
+    }).then(data => {
+      this.setState({
+        walking: data,
+        bicycling: {
+          distance: data.distance,
+          duration: data.duration / 2.6
+        }
+      });
+    });
 
     this.getDistance({
       ...position,

--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -171,24 +171,24 @@ class Kjorskra extends PureComponent {
       JSON.stringify(json)
     ].join('');
 
-    const response = await this.context.fetch(url);
+    let response;
 
-    if (response.status !== 200) {
-      console.error('Error fetching distance', response.status);
+    try {
+      response = await this.context.fetch(url);
+      const data = await response.json();
+      const result = data.trip.summary;
+
+      return {
+        distance: result.length * 1000,
+        duration: result.time
+      };
+    } catch (error) {
+      console.error('Error fetching distance', response && response.status, error);
       return {
         distance: null,
         duration: null
       };
     }
-
-    const data = await response.json();
-
-    const result = data.trip.summary;
-
-    return {
-      distance: result.length * 1000,
-      duration: result.time
-    };
   }
   async getBusDistance({ from, to }) {
     console.log('getBusDistance', from, to);

--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -519,7 +519,6 @@ class Kjorskra extends PureComponent {
                       <Autocomplete
                         ref={this.onAutocompleteMounted}
                         type="text"
-                        onChange={this.submitCurrentAddress}
                         placeholder="Núverandi heimilisfang"
                         className={s.input}
                       />

--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -161,13 +161,8 @@ class Kjorskra extends PureComponent {
       costing
     };
 
-    const api_key =
-      costing === 'pedestrian' ? 'mapzen-8S2Nh1w' : 'mapzen-pRTGdQw';
-
     const url = [
-      'https://valhalla.mapzen.com/route?api_key=',
-      api_key,
-      '&json=',
+      'https://valhalla.mapzen.com/route?api_key=mapzen-pRTGdQw&json=',
       JSON.stringify(json)
     ].join('');
 

--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -153,8 +153,11 @@ class Kjorskra extends PureComponent {
   }
   async getDistance({ from, to, costing }) {
     const json = {
-      sources: [{ lat: from.lat(), lon: from.lng() }],
-      targets: [{ lat: to.lat(), lon: to.lng() }],
+      locations: [
+        { lat: from.lat(), lon: from.lng() },
+        { lat: to.lat(), lon: to.lng() }
+      ],
+      directions_options: { narrative: false },
       costing
     };
 
@@ -162,7 +165,7 @@ class Kjorskra extends PureComponent {
       costing === 'pedestrian' ? 'mapzen-8S2Nh1w' : 'mapzen-pRTGdQw';
 
     const url = [
-      'http://matrix.mapzen.com/one_to_many?api_key=',
+      'https://valhalla.mapzen.com/route?api_key=',
       api_key,
       '&json=',
       JSON.stringify(json)
@@ -180,10 +183,10 @@ class Kjorskra extends PureComponent {
 
     const data = await response.json();
 
-    const result = data.one_to_many[0][0];
+    const result = data.trip.summary;
 
     return {
-      distance: result.distance * 1000,
+      distance: result.length * 1000,
       duration: result.time
     };
   }

--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -23,10 +23,6 @@ import {
   InfoWindow
 } from 'react-google-maps';
 
-const PLACE_OVERRIDE = {
-  Smárinn: 'Dalsmára 5, Kópavogur'
-};
-
 const Map = withGoogleMap(({ mapOptions, kjorstadur }) => {
   return (
     <GoogleMap defaultZoom={mapOptions.zoom} center={mapOptions.center}>
@@ -256,34 +252,34 @@ class Kjorskra extends PureComponent {
     return this.locationFromAddress(place.name);
   }
   async locationFromAddress(address) {
-    if (!process.env.BROWSER) return this.state.mapOptions.center;
+    const url = [
+      'https://search.mapzen.com/v1/search',
+      '?api_key=mapzen-pRTGdQw',
+      '&size=1',
+      '&layers=venue,address',
+      '&boundary.country=is',
+      '&text=',
+      address
+    ].join('');
+    const response = await this.context.fetch(url);
 
-    return new Promise(resolve => {
-      new window.google.maps.Geocoder().geocode(
-        {
-          address,
-          componentRestrictions: {
-            country: 'is'
-          }
-        },
-        results => {
-          if (
-            results.length === 0 ||
-            results[0].formatted_address === 'Iceland'
-          ) {
-            return resolve({
-              invalidLocation: true
-            });
-          }
-          resolve({
-            center: {
-              lat: results[0].geometry.location.lat(),
-              lng: results[0].geometry.location.lng()
-            }
-          });
+    try {
+      const data = await response.json();
+
+      const { coordinates } = data.features[0].geometry;
+
+      return {
+        center: {
+          lat: coordinates[1],
+          lng: coordinates[0]
         }
-      );
-    });
+      }
+    } catch (e) {
+      console.error('Error geocoding address', response.status);
+      return {
+        invalidLocation: true,
+      };
+    }
   }
   onAutocompleteMounted = ref => {
     this.autocomplete = ref;
@@ -342,8 +338,7 @@ class Kjorskra extends PureComponent {
       data
     });
 
-    const address = PLACE_OVERRIDE[data.kjorstadur] || data.kjorstadur;
-    const options = await this.locationFromAddress(address);
+    const options = await this.locationFromAddress(`${data.kjorstadur}, ${data.sveitafelag}`);
 
     this.setState({
       mapOptions: {

--- a/src/routes/kjorskra/Kjorskra.js
+++ b/src/routes/kjorskra/Kjorskra.js
@@ -155,42 +155,41 @@ class Kjorskra extends PureComponent {
   isKennitalaValid() {
     return isPerson(this.state.kennitala);
   }
-  async getDistance({ from, to, mode }) {
-    if (!process.env.BROWSER) return { distance: null, duration: null };
-    return new Promise(resolve => {
-      new window.google.maps.DistanceMatrixService().getDistanceMatrix(
-        {
-          origins: [from],
-          destinations: [to],
-          travelMode: mode //BICYCLING,WALKING,DRIVING
-        },
-        results => {
-          if (results.rows.length === 0) {
-            console.error('No results from distance matrix');
-            return;
-          }
+  async getDistance({ from, to, costing }) {
+    const json = {
+      sources: [{ lat: from.lat(), lon: from.lng() }],
+      targets: [{ lat: to.lat(), lon: to.lng() }],
+      costing
+    };
 
-          let distance = null;
-          let duration = null;
+    const api_key =
+      costing === 'pedestrian' ? 'mapzen-8S2Nh1w' : 'mapzen-pRTGdQw';
 
-          results.rows.forEach(row => {
-            row.elements.forEach(element => {
-              if (element && element.distance) {
-                distance = element.distance.value;
-              }
-              if (element && element.duration) {
-                duration = element.duration.value;
-              }
-            });
-          });
+    const url = [
+      'http://matrix.mapzen.com/one_to_many?api_key=',
+      api_key,
+      '&json=',
+      JSON.stringify(json)
+    ].join('');
 
-          resolve({
-            distance,
-            duration
-          });
-        }
-      );
-    });
+    const response = await this.context.fetch(url);
+
+    if (response.status !== 200) {
+      console.error('Error fetching distance', response.status);
+      return {
+        distance: null,
+        duration: null
+      };
+    }
+
+    const data = await response.json();
+
+    const result = data.one_to_many[0][0];
+
+    return {
+      distance: result.distance * 1000,
+      duration: result.time
+    };
   }
   async getBusDistance({ from, to }) {
     console.log('getBusDistance', from, to);
@@ -409,17 +408,17 @@ class Kjorskra extends PureComponent {
     //Look up all the itineries and emit them asynchronous
     this.getDistance({
       ...position,
-      mode: 'WALKING'
+      costing: 'pedestrian'
     }).then(data => this.setState({ walking: data }));
 
     this.getDistance({
       ...position,
-      mode: 'BICYCLING'
+      costing: 'bicycle'
     }).then(data => this.setState({ bicycling: data }));
 
     this.getDistance({
       ...position,
-      mode: 'DRIVING'
+      costing: 'auto'
     }).then(data => this.setState({ driving: data }));
 
     this.getBusDistance({


### PR DESCRIPTION
This replaces the geocoding done on the kjorskra page that was done using Google, with Mapzen. Mapzen is using data from OpenStreetMap which has much better data for Iceland. I did a few tests with some kjorstad addresses that I knew didn't work with the Google API, but now works with Mapzen.

This only replaces the lookup of addresses and the time it takes to get to the kjorstadur. Autocomplete and the map itself is still using Google. I would want to change those too, but time is running out! This should at least fix the lookup of the kjorstad addresses.

----

One gotcha; They have a very strict requests-per-second limit, but I contacted their support and they agreed to increase the limits for my API key. It is still fairly low, but should be enough: 20 rps for search (address to geolocation), and 6 rps for route (to get the time it takes to get to the kjorstadur).

When you enter your kennitala, we do one search.
When you enter an address, we do one search and 3 route requests.

The max within one second is then basically 18 people entering their kennitala, and 2 people entering their address.

That should be enough, right?