### PR TITLE
fix(Collapsable): use history.replace() intead of .push()

### DIFF
--- a/src/components/Collapsable/Collapsable.js
+++ b/src/components/Collapsable/Collapsable.js
@@ -67,7 +67,7 @@ class Collapsable extends React.Component {
       // Scroll to collapsable only when opening.
       if (nextState && target.offsetParent) {
         this.scrollTo(target);
-        history.push(`#${key}`);
+        history.replace(`#${key}`);
       }
 
       return { open };


### PR DESCRIPTION
On the `/flokkur/:party` route, after expanding the Collapsable's, the browser history fills up with the hash links.

Expected: Pressing back in the browser is expected to go to the previous page.
Actual: Pressing back in the browser scrolls to previous "Collapsable" that was expanded.