### PR TITLE
Revert 2024 questions

### DIFF
--- a/data/poll/questions.json
+++ b/data/poll/questions.json
@@ -1,23 +1,23 @@
 [
   {
     "id": 1,
-    "question": "Öðrum en ríkinu ætti að vera heimilt að reka áfengisverslun á Íslandi."
+    "question": "Allir landsmenn ættu að hafa aðgang að grunnheilbrigðisþjónustu í sinni heimabyggð."
   },
   {
     "id": 2,
-    "question": "Stjórnvöld eiga að standa vörð um stöðu Þjóðkirkjunnar í íslensku samfélagi."
+    "question": "Leyfa ætti aukinn einkarekstur í heilbrigðiskerfinu."
   },
   {
     "id": 3,
-    "question": "Þyngja ætti refsingar í kynferðis- og heimilisofbeldismálum."
+    "question": "Borgarlínan er jákvætt framlag til samgöngumála á stórhöfuðborgarsvæðinu."
   },
   {
     "id": 4,
-    "question": "Efna á til þjóðaratkvæðagreiðslu um hvort hefja eigi að nýju aðildarviðræður við ESB."
+    "question": "Ísland á í samvinnu við alþjóðastofnanir að taka við fleiri umsækjendum um alþjóðlega vernd."
   },
   {
     "id": 5,
-    "question": "Skipta ætti út íslensku krónunni fyrir annan erlendan gjaldmiðil."
+    "question": "Menntasjóður Námsmanna ætti að veita háskólanemum námsstyrki, að minnsta kosti að hluta til."
   },
   {
     "id": 6,
@@ -29,91 +29,91 @@
   },
   {
     "id": 8,
-    "question": "Ríkið ætti að niðurgreiða sálfræðiþjónustu."
+    "question": "Hækka þarf ellilífeyrisbætur svo þær samsvari lægstu launum hverju sinni."
   },
   {
     "id": 9,
-    "question": "Afglæpavæða ætti neysluskammta fíkniefna á kjörtímabilinu."
+    "question": "Samþykkja ætti nýja stjórnarskrá sem væri að fullu í samræmi við tillögur Stjórnarlagaráðs."
   },
   {
     "id": 10,
-    "question": "Allir landsmenn ættu að hafa aðgang að grunnheilbrigðisþjónustu í sinni heimabyggð."
+    "question": "Á næsta kjörtímabilinu ætti að ljúka heildarendurskoðun stjórnarskrárinnar."
   },
   {
     "id": 11,
-    "question": "Leyfa ætti aukinn einkarekstur í heilbrigðiskerfinu."
+    "question": "Efna á til þjóðaratkvæðagreiðslu um hvort hefja eigi að nýju aðildarviðræður við ESB."
   },
   {
     "id": 12,
-    "question": "Setja ætti lög um leiguþak á húsnæðismarkaði."
+    "question": "Auka á framlög Íslands til þróunarsamvinnu og hjálparstarfsemi í fátækari ríkjum heims."
   },
   {
     "id": 13,
-    "question": "Afnema ætti verðtryggingu húsnæðislána."
+    "question": "NATO á að fá að byggja upp aðstöðu fyrir hersveitir á Keflavíkurflugvelli á ný."
   },
   {
     "id": 14,
-    "question": "Stjórnvöld eiga að láta markaðsöfl stýra húsnæðismarkaðnum."
-  },
-  {
-    "id": 15,
-    "question": "Ríkið ætti að koma að uppbyggingu nýs þjóðarleikvangs á komandi kjörtímabili."
-  },
-  {
-    "id": 16,
-    "question": "Reykjavíkurflugvöllur á að vera áfram í Vatnsmýri."
-  },
-  {
-    "id": 17,
-    "question": "Leggja þarf áherslu á fjárfestingar í innviðum (t.d. í samgöngum, fjarskiptum og heilbrigðiskerfi) áður en ráðist er í að niðurgreiða skuldir ríkissjóðs."
-  },
-  {
-    "id": 18,
-    "question": "Mikilvægt er að hið opinbera leysi vanda sauðfjárbænda vegna búvörusamninga með fjárframlögum."
-  },
-  {
-    "id": 19,
-    "question": "Fjármagna ætti uppbyggingu vegakerfisins í nágrenni höfuðborgarsvæðisins með vegatollum."
-  },
-  {
-    "id": 20,
     "question": "Flytja á fleiri opinberar stofnanir út á land."
   },
   {
+    "id": 15,
+    "question": "Stjórnvöld eiga að standa vörð um stöðu Þjóðkirkjunnar í íslensku samfélagi."
+  },
+  {
+    "id": 16,
+    "question": "Þyngja ætti refsingar í kynferðis- og heimilisofbeldismálum."
+  },
+  {
+    "id": 17,
+    "question": "Mikilvægt er að hið opinbera leysi vanda sauðfjárbænda vegna búvörusamninga með fjárframlögum."
+  },
+  {
+    "id": 18,
+    "question": "Fjármagna ætti uppbyggingu vegakerfisins í nágrenni höfuðborgarsvæðisins með vegatollum."
+  },
+  {
+    "id": 19,
+    "question": "Hið opinbera á að tryggja fjölbreytta möguleika til menntunar um allt land."
+  },
+  {
+    "id": 20,
+    "question": "Afglæpavæða ætti neyslu kannabis á kjörtímabilinu."
+  },
+  {
     "id": 21,
-    "question": "Auka ætti einkarekstur í leik og grunnskólaþjónustu."
+    "question": "Stjórnvöld eiga að láta markaðsöfl stýra húsnæðismarkaðnum."
   },
   {
     "id": 22,
-    "question": "Ríkið á að selja hlut sinn í orkufyrirtækjum."
+    "question": "Leggja þarf áherslu á fjárfestingar í innviðum (t.d. í samgöngum, fjarskiptum og heilbrigðiskerfi) áður en ráðist er í að niðurgreiða skuldir ríkissjóðs."
   },
   {
     "id": 23,
-    "question": "Hagsmunir náttúrunnar eiga að vega þyngra en fjárhagslegir hagsmunir við ákvarðanatöku stjórnvalda í atvinnuuppbyggingu."
+    "question": "Ríkið á að eiga og reka að minnsta kosti einn banka á Íslandi."
   },
   {
     "id": 24,
-    "question": "Stofna ætti hálendisþjóðgarð til að vernda náttúru Íslands."
+    "question": "Lækka þarf launaskattinn (tryggingagjald) sem fyrirtæki greiða til ríkisins."
   },
   {
     "id": 25,
-    "question": "Einkavæða ætti orkuframleiðslu á Íslandi í auknu mæli."
+    "question": "Hækka þarf hátekjuskatt."
   },
   {
     "id": 26,
-    "question": "Auka ætti græna orkuframleiðslu með virkjunum (s.s. vind og vatns virkjanir) á Íslandi."
+    "question": "Skipta ætti út íslensku krónunni fyrir annan erlendan gjaldmiðil."
   },
   {
     "id": 27,
-    "question": "Borgarlínan er jákvætt framlag til samgöngumála á stórhöfuðborgarsvæðinu."
+    "question": "Það er mikilvægt að neytendur fái að kaupa innflutt matvæli."
   },
   {
     "id": 28,
-    "question": "Banna ætti hvalveiðar við Ísland."
+    "question": "Leyfa ætti sölu áfengis í matvöruverslunum á Íslandi."
   },
   {
     "id": 29,
-    "question": "Banna ætti sjókvíaeldi."
+    "question": "Mikilvægt er að ríkið beiti sér fyrir bættri aðstöðu og aðgengi á ferðamannastöðum í sinni eigu."
   },
   {
     "id": 30,
@@ -121,30 +121,42 @@
   },
   {
     "id": 31,
-    "question": "Hækka ætti skattleysismörk."
+    "question": "Ríkið á að selja hlut sinn í orkufyrirtækjum."
   },
   {
     "id": 32,
-    "question": "Hækka þarf hátekjuskatt."
+    "question": "Hagsmunir náttúrunnar eiga að vega þyngra en fjárhagslegir hagsmunir við ákvarðanatöku stjórnvalda í atvinnuuppbyggingu."
   },
   {
     "id": 33,
-    "question": "Ríkið á að eiga og reka að minnsta kosti einn banka á Íslandi."
+    "question": "Ríkisstjórnin á að fara að tillögum sóttvarnarlæknis við COVID-19 jafnvel þó þær hafi neikvæð áhrif á efnahagslífið."
   },
   {
     "id": 34,
-    "question": "Auka á framlög Íslands til þróunarsamvinnu og hjálparstarfsemi í fátækari ríkjum heims."
+    "question": "Stofna ætti hálendisþjóðgarð til að vernda náttúru Íslands."
   },
   {
     "id": 35,
-    "question": "Fjöldi flóttafólks sem fær hæli á Íslandi er of mikill."
+    "question": "Reykjavíkurflugvöllur á að vera áfram í Vatnsmýri."
   },
   {
     "id": 36,
-    "question": "Ísland ætti að beita Ísraelsríki viðskiptaþvingunum vegna framgöngu þeirra gagnvart Palestínumönnum."
+    "question": "Taka ætti fyrir kaup erlendra einstaklinga og fyrirtækja á stórum jörðum á Íslandi."
   },
   {
     "id": 37,
-    "question": "Það er mikilvægt að neytendur fái að kaupa innflutt matvæli."
+    "question": "Núverandi tímamörk um bann á innflutningi á bílum sem ganga fyrir jarðefnaeldsneyti árið 2030 ættu að ganga lengra og vera styttri."
+  },
+  {
+    "id": 38,
+    "question": "Banna á leit að jarðefnaeldsneyti í lögsögu Íslands."
+  },
+  {
+    "id": 39,
+    "question": "Auka þarf eftirlit og eftirfylgni á sjó til að stuðla að náttúruvernd t.d. er varðar brottkast fisks."
+  },
+  {
+    "id": 40,
+    "question": "Mikilvægt er að stjórnvöld móti heildstæða aðgerðaráætlun fyrir íslenskt hringrásarhagkerfi, t.d. fyrir endurvinnslu, endurnýtingu, flokkun sorps og fleira."
   }
 ]

--- a/src/routes/prof-nidurstodur/KosningaProf.js
+++ b/src/routes/prof-nidurstodur/KosningaProf.js
@@ -20,7 +20,7 @@ const initialAnswers = questions =>
 
 const marks = {
   0: 'Mjög ósammála',
-  3: 'Hlutlaus',
+  2: 'Hlutlaus',
   4: 'Mjög sammála',
 };
 

--- a/src/svt-process-replies.js
+++ b/src/svt-process-replies.js
@@ -17,23 +17,20 @@ function parseAnswerToSVT(answers) {
 }
 
 function parsePoliticalAnswerToSVT(answers) {
-  return answers
-    .split('')
-    .slice(0, 37) // this is only here temporarily to test old answers compared to the 37 new questions
-    .map(answer => {
-      // 6 means the user skipped it or didnt answer it
-      if (answer === '6') {
-        return null;
-      }
-      // SVT uses 4-level Likert scale by default while we use 5 level
-      // To make it work with the 5-level scale we need to set the type as range
-      return { 
-        selectedIndex: answer - 1,
-        // Used to test out the scale
-        isImportant: Math.random() < 0.5,
-        type: 'RANGE' 
-      };
-    });
+  return answers.split('').map(answer => {
+    // 6 means the user skipped it or didnt answer it
+    if (answer === '6') {
+      return null;
+    }
+    // SVT uses 4-level Likert scale by default while we use 5 level
+    // To make it work with the 5-level scale we need to set the type as range
+    return {
+      selectedIndex: answer - 1,
+      // Used to test out the scale
+      isImportant: Math.random() < 0.5,
+      type: 'RANGE',
+    };
+  });
 }
 
 export default function getResultsBySVTScore(userAnswer, politialEntityAnswer) {


### PR DESCRIPTION
We aren't quite ready for the 2024 questions to be published, as the old answers will not match the new question set.
Until we are ready to publish the new questions, lets revert and use the old ones