### PR TITLE
disable kosningaprof from the Header

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -65,14 +65,14 @@ class Header extends PureComponent {
       // >
       //   Kjörstaðir
       // </Link>,
-      <Link
-        afterClick={() => this.toggle(false)}
-        href="/kosningaprof"
-        key="/kosningaprof"
-        className={cx(page === 'kosningaprof' ? s.active : null)}
-      >
-        Kosningapróf
-      </Link>,
+      // <Link
+      //   afterClick={() => this.toggle(false)}
+      //   href="/kosningaprof"
+      //   key="/kosningaprof"
+      //   className={cx(page === 'kosningaprof' ? s.active : null)}
+      // >
+      //   Kosningapróf
+      // </Link>,
       <Link
         afterClick={() => this.toggle(false)}
         href="/flokkar/bera-saman"


### PR DESCRIPTION
This kosningaprof is the old one from 2021 but people are taking it and looking at the results as it is for 2024. Lets temporarily disable it until we have the new one live