### PR TITLE
inserting information header about 2021 election

### DIFF
--- a/src/routes/prof-nidurstodur/KosningaProf.js
+++ b/src/routes/prof-nidurstodur/KosningaProf.js
@@ -303,6 +303,12 @@ class Kosningaprof extends PureComponent {
     return (
       <div className={s.lead}>
         <p>
+          <strong>
+            Við erum að vinna í að uppfæra prófið fyrir kosningarnar 2024 en
+            þangað til geturu tekið prófið frá árinu 2021
+          </strong>
+        </p>
+        <p>
           Taktu kosningarpróf <strong>Kjóstu rétt</strong> til þess að sjá hvaða
           flokkur passar best við þínar skoðanir. Því fleiri spurningum sem þú
           svarar, því nákvæmari niðurstöður færðu.


### PR DESCRIPTION
People are taking the 2021 test expecting it to be updated. Adding a bold text at the top to highlight that currently this test is the test from 2021