### PR TITLE
changing sorting and colors

### DIFF
--- a/src/routes/prof-nidurstodur/KosningaProfResults.js
+++ b/src/routes/prof-nidurstodur/KosningaProfResults.js
@@ -256,6 +256,13 @@ class KosningaprofResults extends PureComponent {
                       }
                       // secondary sorting by how strongly the user feels
                       if (aAgree - bAgree === 0) {
+                        // Going from agree to not agree should be the color red and be lower on the scale
+                        const crossesAgreement =
+                          (a.myAnswer === 1 && a.partyAnswer === 2) ||
+                          (a.myAnswer === 2 && a.partyAnswer === 1);
+                        if (crossesAgreement) {
+                          return 1;
+                        }
                         if (a.myAnswer < b.myAnswer) {
                           return 1;
                         } else {
@@ -267,6 +274,9 @@ class KosningaprofResults extends PureComponent {
                     .map(({ id, myAnswer, question, partyAnswer }) => {
                       const iAmIndiffrent = myAnswer === 6;
                       const partyIndiffrent = partyAnswer === 6;
+                      const crossesAgreement =
+                        (myAnswer === 1 && partyAnswer === 2) ||
+                        (myAnswer === 2 && partyAnswer === 1);
 
                       const difference = Math.abs(myAnswer - partyAnswer);
 
@@ -278,7 +288,10 @@ class KosningaprofResults extends PureComponent {
                                 s.dot,
                                 !iAmIndiffrent &&
                                   !partyIndiffrent &&
-                                  s[`dot${difference}`]
+                                  s[`dot${difference}`],
+                                {
+                                  [s.dotCrossesAgreement]: crossesAgreement,
+                                }
                               )}
                             />
                             {question}

--- a/src/routes/prof-nidurstodur/styles.scss
+++ b/src/routes/prof-nidurstodur/styles.scss
@@ -494,13 +494,18 @@
   }
 
   .dot2 {
+    background-color: #c21716;
+    box-shadow: 0 0 4px 0 #c21716;
+  }
+  
+  .dotCrossesAgreement {
     background-color: #d39537;
     box-shadow: 0 0 4px 0 #d39537;
   }
 
   .dot3 {
-    background-color: #c21716;
-    box-shadow: 0 0 4px 0 #c21716;
+    background-color: #7e0505;
+    box-shadow: 0 0 4px 0 #7e0505;
   }
 
   @media (min-width: 600px) {


### PR DESCRIPTION
We got feedback that when you cross over from agreement to non agreement the color should be more "negative", even though the travel distance between the answers is just one. Adding a check for that and making sure we use the secondary sort on it as well